### PR TITLE
修改工作流程以支持配置 Emby 容器的内存限制

### DIFF
--- a/.github/workflows/embyserver_latest_version.yml
+++ b/.github/workflows/embyserver_latest_version.yml
@@ -1,54 +1,61 @@
 name: embyserver latest version
 
 on:
-    workflow_dispatch:
-    push:
-        branches:
-            - master
-        paths:
-            - ".github/workflows/embyserver_latest_version.yml"
+  workflow_dispatch:
+    inputs:
+      memory_limit: # 添加输入参数
+        description: "Emby 容器的内存限制 (例如：1g, 512m)"
+        required: false # 设置为 false，以便在未提供时使用默认值
+        default: "1g" # 默认值为 1GB
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/embyserver_latest_version.yml"
 
 jobs:
   get:
     runs-on: ubuntu-latest
     steps:
-      - 
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
 
-      -
-        name: Get Latest Version Amilys
+      - name: Get Latest Version Amilys
         run: |
-            docker run --memory=1g --entrypoint cp -v ${PWD}/emby:/data amilys/embyserver:latest /system/EmbyServer.deps.json /data
-            LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
-            sed -i "1,40s|amilys_embyserver_latest_version=.*|amilys_embyserver_latest_version=${LATEST_VERSION}|" all_in_one.sh
+          # 使用输入参数，如果未提供，则使用默认值
+          MEMORY_LIMIT=${{ github.event.inputs.memory_limit || '1g' }}
+          docker run --memory=${MEMORY_LIMIT} --entrypoint cp -v ${PWD}/emby:/data amilys/embyserver:latest /system/EmbyServer.deps.json /data
+          LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
+          sed -i "1,40s|amilys_embyserver_latest_version=.*|amilys_embyserver_latest_version=${LATEST_VERSION}|" all_in_one.sh
 
-      -
-        name: Get Latest Version Emby
+      - name: Get Latest Version Emby
         run: |
-            docker run --memory=1g --entrypoint cp -v ${PWD}/emby:/data emby/embyserver:latest /system/EmbyServer.deps.json /data
-            LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
-            sed -i "1,40s|emby_embyserver_latest_version=.*|emby_embyserver_latest_version=${LATEST_VERSION}|" all_in_one.sh
+          # 使用输入参数
+          MEMORY_LIMIT=${{ github.event.inputs.memory_limit || '1g' }}
+          docker run --memory=${MEMORY_LIMIT} --entrypoint cp -v ${PWD}/emby:/data emby/embyserver:latest /system/EmbyServer.deps.json /data
+          LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
+          sed -i "1,40s|emby_embyserver_latest_version=.*|emby_embyserver_latest_version=${LATEST_VERSION}|" all_in_one.sh
 
-      -
-        name: Get Beta Version Amilys
+      - name: Get Beta Version Amilys
         run: |
-            docker run --memory=1g --entrypoint cp -v ${PWD}/emby:/data amilys/embyserver:beta /system/EmbyServer.deps.json /data
-            LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
-            sed -i "1,40s|amilys_embyserver_beta_version=.*|amilys_embyserver_beta_version=${LATEST_VERSION}|" all_in_one.sh
+          # 使用输入参数
+          MEMORY_LIMIT=${{ github.event.inputs.memory_limit || '1g' }}
+          docker run --memory=${MEMORY_LIMIT} --entrypoint cp -v ${PWD}/emby:/data amilys/embyserver:beta /system/EmbyServer.deps.json /data
+          LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
+          sed -i "1,40s|amilys_embyserver_beta_version=.*|amilys_embyserver_beta_version=${LATEST_VERSION}|" all_in_one.sh
 
-      -
-        name: Get Beta Version Emby
+      - name: Get Beta Version Emby
         run: |
-            docker run --memory=1g --entrypoint cp -v ${PWD}/emby:/data emby/embyserver:beta /system/EmbyServer.deps.json /data
-            LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
-            sed -i "1,40s|emby_embyserver_beta_version=.*|emby_embyserver_beta_version=${LATEST_VERSION}|" all_in_one.sh
+          # 使用输入参数
+          MEMORY_LIMIT=${{ github.event.inputs.memory_limit || '1g' }}
+          docker run --memory=${MEMORY_LIMIT} --entrypoint cp -v ${PWD}/emby:/data emby/embyserver:beta /system/EmbyServer.deps.json /data
+          LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
+          sed -i "1,40s|emby_embyserver_beta_version=.*|emby_embyserver_beta_version=${LATEST_VERSION}|" all_in_one.sh
 
-      - 
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-            commit_message: 'chore: update embyserver latest version'
-            branch: master
-            file_pattern: 'all_in_one.sh'
+          commit_message: 'chore: update embyserver latest version'
+          branch: master
+          file_pattern: 'all_in_one.sh'
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/embyserver_latest_version.yml
+++ b/.github/workflows/embyserver_latest_version.yml
@@ -19,28 +19,28 @@ jobs:
       -
         name: Get Latest Version Amilys
         run: |
-            docker run --entrypoint cp -v ${PWD}/emby:/data amilys/embyserver:latest /system/EmbyServer.deps.json /data
+            docker run --memory=1g --entrypoint cp -v ${PWD}/emby:/data amilys/embyserver:latest /system/EmbyServer.deps.json /data
             LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
             sed -i "1,40s|amilys_embyserver_latest_version=.*|amilys_embyserver_latest_version=${LATEST_VERSION}|" all_in_one.sh
 
       -
         name: Get Latest Version Emby
         run: |
-            docker run --entrypoint cp -v ${PWD}/emby:/data emby/embyserver:latest /system/EmbyServer.deps.json /data
+            docker run --memory=1g --entrypoint cp -v ${PWD}/emby:/data emby/embyserver:latest /system/EmbyServer.deps.json /data
             LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
             sed -i "1,40s|emby_embyserver_latest_version=.*|emby_embyserver_latest_version=${LATEST_VERSION}|" all_in_one.sh
 
       -
         name: Get Beta Version Amilys
         run: |
-            docker run --entrypoint cp -v ${PWD}/emby:/data amilys/embyserver:beta /system/EmbyServer.deps.json /data
+            docker run --memory=1g --entrypoint cp -v ${PWD}/emby:/data amilys/embyserver:beta /system/EmbyServer.deps.json /data
             LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
             sed -i "1,40s|amilys_embyserver_beta_version=.*|amilys_embyserver_beta_version=${LATEST_VERSION}|" all_in_one.sh
 
       -
         name: Get Beta Version Emby
         run: |
-            docker run --entrypoint cp -v ${PWD}/emby:/data emby/embyserver:beta /system/EmbyServer.deps.json /data
+            docker run --memory=1g --entrypoint cp -v ${PWD}/emby:/data emby/embyserver:beta /system/EmbyServer.deps.json /data
             LATEST_VERSION=$(grep "EmbyServer" emby/EmbyServer.deps.json | head -n 1 | sed -n 's|.*EmbyServer/\(.*\)":.*|\1|p')
             sed -i "1,40s|emby_embyserver_beta_version=.*|emby_embyserver_beta_version=${LATEST_VERSION}|" all_in_one.sh
 


### PR DESCRIPTION
更改说明
本拉取请求实现了以下更改：
修改工作流程以支持配置 Emby 容器的内存限制。
在 workflow_dispatch 下添加了一个新的 memory_limit 输入参数，允许用户在触发工作流程时指定所需的内存限制。
更新了 docker run 命令，以使用提供的 memory_limit 参数。如果未提供参数，则默认为 1g。

动机
允许用户根据其特定需求和系统资源调整 Emby 容器的内存使用，从而提高了工作流程的灵活性。

详细信息
输入参数：
memory_limit：一个可选参数，用于指定 Emby 容器的内存限制。它接受诸如 1g、512m 等值。

Docker 运行命令：
docker run 命令已更新为包含 --memory 标志，其值设置为 ${{ github.event.inputs.memory_limit }}。

默认值：
如果未提供 memory_limit 参数，则使用默认值 1g。

影响
我是菜鸟，AI帮改的代码，未测试，不知道有无bug。